### PR TITLE
Healthcheck supports HTTP.

### DIFF
--- a/healthcheck/healthcheck_test.go
+++ b/healthcheck/healthcheck_test.go
@@ -2,7 +2,9 @@ package main_test
 
 import (
 	"net"
+	"net/http"
 	"os/exec"
+	"time"
 
 	. "github.com/cloudfoundry-incubator/buildpack_app_lifecycle/Godeps/_workspace/src/github.com/onsi/ginkgo"
 	. "github.com/cloudfoundry-incubator/buildpack_app_lifecycle/Godeps/_workspace/src/github.com/onsi/gomega"
@@ -28,31 +30,92 @@ var _ = Describe("HealthCheck", func() {
 		server.Start()
 	})
 
-	runHealthCheck := func() *gexec.Session {
-		_, port, err := net.SplitHostPort(serverAddr)
-		Expect(err).NotTo(HaveOccurred())
-		session, err := gexec.Start(exec.Command(healthCheck, "-port", port, "-timeout", "100ms"), GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		return session
-	}
+	Describe("port healthcheck", func() {
+		portHealthCheck := func() *gexec.Session {
+			_, port, err := net.SplitHostPort(serverAddr)
+			Expect(err).NotTo(HaveOccurred())
+			session, err := gexec.Start(exec.Command(healthCheck, "-port", port, "-timeout", "100ms"), GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			return session
+		}
 
-	Context("when the address is listening", func() {
-		It("exits 0 and logs it passed", func() {
-			session := runHealthCheck()
-			Eventually(session).Should(gexec.Exit(0))
-			Expect(session.Out).To(gbytes.Say("healthcheck passed"))
+		Context("when the address is listening", func() {
+			It("exits 0 and logs it passed", func() {
+				session := portHealthCheck()
+				Eventually(session).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say("healthcheck passed"))
+			})
+		})
+
+		Context("when the address is not listening", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+
+			It("exits 1 and logs it failed", func() {
+				session := portHealthCheck()
+				Eventually(session).Should(gexec.Exit(1))
+				Expect(session.Out).To(gbytes.Say("healthcheck failed"))
+			})
 		})
 	})
 
-	Context("when the address is not listening", func() {
-		BeforeEach(func() {
-			server.Close()
-		})
+	Describe("http healthcheck", func() {
+		Context("when the healthcheck is properly invoked", func() {
+			httpHealthCheck := func() *gexec.Session {
+				_, port, err := net.SplitHostPort(serverAddr)
+				Expect(err).NotTo(HaveOccurred())
+				session, err := gexec.Start(exec.Command(healthCheck, "-uri", "/api/_ping", "-port", port, "-timeout", "100ms"), GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				return session
+			}
 
-		It("exits 1 and logs it failed", func() {
-			session := runHealthCheck()
-			Eventually(session).Should(gexec.Exit(1))
-			Expect(session.Out).To(gbytes.Say("healthcheck failed"))
+			itFailsHttpHealthCheck := func() {
+				It("exits 1 and logs it failed", func() {
+					session := httpHealthCheck()
+					Eventually(session).Should(gexec.Exit(1))
+					Expect(session.Out).To(gbytes.Say("healthcheck failed"))
+				})
+			}
+
+			BeforeEach(func() {
+				server.RouteToHandler("GET", "/api/_ping", ghttp.VerifyRequest("GET", "/api/_ping"))
+			})
+
+			Context("when the address is listening", func() {
+				It("exits 0 and logs it passed", func() {
+					session := httpHealthCheck()
+					Eventually(session).Should(gexec.Exit(0))
+					Expect(session.Out).To(gbytes.Say("healthcheck passed"))
+				})
+			})
+
+			Context("when the address returns error http code", func() {
+				BeforeEach(func() {
+					server.RouteToHandler("GET", "/api/_ping", ghttp.RespondWith(500, ""))
+				})
+
+				itFailsHttpHealthCheck()
+			})
+
+			Context("when the address is not listening", func() {
+				BeforeEach(func() {
+					server.Close()
+				})
+
+				itFailsHttpHealthCheck()
+			})
+
+			Context("when the server is too slow to respond", func() {
+				BeforeEach(func() {
+					server.RouteToHandler("GET", "/api/_ping", func(w http.ResponseWriter, req *http.Request) {
+						time.Sleep(2 * time.Second)
+						w.WriteHeader(http.StatusOK)
+					})
+				})
+
+				itFailsHttpHealthCheck()
+			})
 		})
 	})
 })


### PR DESCRIPTION
As part of [#92064340](https://www.pivotaltracker.com/story/show/92064340), we extended the functionality of the `buildpack_app_lifecycle/healthcheck` to perform a HTTP round-trip and verify the app responds with a proper 200 OK status code.

`healthcheck` now takes an `-http` flag that takes the format `PORT:URI`, such as `-http 8080:/api/ping`.  

Because we don't want conflicting flags, we removed defaulting the port flag to *8080*.  Let us know if anything is relying on this.

Thanks,
David + KL