### PR TITLE
ensure submodules are updated on branch checkout

### DIFF
--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -22,6 +22,7 @@ func TestBuildpackrunner(t *testing.T) {
 var tmpDir string
 var httpServer *httptest.Server
 var gitUrl url.URL
+var fileGitUrl url.URL
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	gitPath, err := exec.LookPath("git")
@@ -45,6 +46,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	execute(buildpackDir, gitPath, "add", ".")
 	execute(buildpackDir, gitPath, "add", "-A")
 	execute(buildpackDir, gitPath, "commit", "-am", "fake commit")
+	execute(buildpackDir, gitPath, "commit", "--allow-empty", "-m", "empty commit")
 	execute(buildpackDir, gitPath, "branch", "a_branch")
 	execute(buildpackDir, gitPath, "tag", "-m", "annotated tag", "a_tag")
 	execute(buildpackDir, gitPath, "tag", "a_lightweight_tag")
@@ -57,6 +59,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Host:   httpServer.Listener.Addr().String(),
 		Path:   "/fake-buildpack/.git",
 	}
+	fileGitUrl = url.URL{
+		Scheme: "file",
+		Path:   buildpackDir,
+	}
+
 	return []byte(gitUrl.String())
 }, func(data []byte) {
 	u, err := url.Parse(string(data))

--- a/buildpackrunner/buildpackrunner_suite_test.go
+++ b/buildpackrunner/buildpackrunner_suite_test.go
@@ -34,22 +34,38 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	err = os.MkdirAll(buildpackDir, os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
 
+	submoduleDir := filepath.Join(tmpDir, "submodule")
+	err = os.MkdirAll(submoduleDir, os.ModePerm)
+	Expect(err).NotTo(HaveOccurred())
+
 	execute(buildpackDir, "rm", "-rf", ".git")
 	execute(buildpackDir, gitPath, "init")
 	execute(buildpackDir, gitPath, "config", "user.email", "you@example.com")
 	execute(buildpackDir, gitPath, "config", "user.name", "your name")
+	writeFile(filepath.Join(buildpackDir, "content"), "some content")
 
-	err = ioutil.WriteFile(filepath.Join(buildpackDir, "content"),
-		[]byte("some content"), os.ModePerm)
-	Expect(err).NotTo(HaveOccurred())
+	execute(submoduleDir, "rm", "-rf", ".git")
+	execute(submoduleDir, gitPath, "init")
+	execute(submoduleDir, gitPath, "config", "user.email", "you@example.com")
+	execute(submoduleDir, gitPath, "config", "user.name", "your name")
+	writeFile(filepath.Join(submoduleDir, "README"), "1st commit")
+	execute(submoduleDir, gitPath, "add", ".")
+	execute(submoduleDir, gitPath, "commit", "-am", "first commit")
+	writeFile(filepath.Join(submoduleDir, "README"), "2nd commit")
+	execute(submoduleDir, gitPath, "commit", "-am", "second commit")
 
-	execute(buildpackDir, gitPath, "add", ".")
+	execute(buildpackDir, gitPath, "submodule", "add", "file://"+submoduleDir, "sub")
+	execute(buildpackDir+"/sub", gitPath, "checkout", "HEAD^")
 	execute(buildpackDir, gitPath, "add", "-A")
-	execute(buildpackDir, gitPath, "commit", "-am", "fake commit")
+	execute(buildpackDir, gitPath, "commit", "-m", "fake commit")
 	execute(buildpackDir, gitPath, "commit", "--allow-empty", "-m", "empty commit")
-	execute(buildpackDir, gitPath, "branch", "a_branch")
 	execute(buildpackDir, gitPath, "tag", "-m", "annotated tag", "a_tag")
 	execute(buildpackDir, gitPath, "tag", "a_lightweight_tag")
+	execute(buildpackDir, gitPath, "checkout", "-b", "a_branch")
+	execute(buildpackDir+"/sub", gitPath, "checkout", "master")
+	execute(buildpackDir, gitPath, "add", "-A")
+	execute(buildpackDir, gitPath, "commit", "-am", "update submodule")
+	execute(buildpackDir, gitPath, "checkout", "master")
 	execute(buildpackDir, gitPath, "update-server-info")
 
 	httpServer = httptest.NewServer(http.FileServer(http.Dir(tmpDir)))
@@ -81,5 +97,11 @@ func execute(dir string, execCmd string, args ...string) {
 	cmd := exec.Command(execCmd, args...)
 	cmd.Dir = dir
 	err := cmd.Run()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func writeFile(filepath, content string) {
+	err := ioutil.WriteFile(filepath,
+		[]byte(content), os.ModePerm)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/buildpackrunner/git_buildpack.go
+++ b/buildpackrunner/git_buildpack.go
@@ -18,7 +18,7 @@ func GitClone(repo url.URL, destination string) error {
 
 	args := []string{
 		"clone",
-		"-depth",
+		"--depth",
 		"1",
 	}
 

--- a/buildpackrunner/git_buildpack.go
+++ b/buildpackrunner/git_buildpack.go
@@ -16,36 +16,37 @@ func GitClone(repo url.URL, destination string) error {
 	repo.Fragment = ""
 	gitUrl := repo.String()
 
-	args := []string{
-		"clone",
-		"--depth",
-		"1",
-	}
-
-	if branch != "" {
-		args = append(args, "-b", branch)
-	}
-
-	args = append(args, "--recursive", gitUrl, destination)
-	cmd := exec.Command(gitPath, args...)
-
-	err = cmd.Run()
+	err = performGitClone(gitPath,
+		[]string{
+			"--depth",
+			"1",
+			"--recursive",
+			gitUrl,
+			destination,
+		}, branch)
 
 	if err != nil {
-		cmd = exec.Command(gitPath, "clone", "--recursive", gitUrl, destination)
-		err = cmd.Run()
+		err = performGitClone(gitPath,
+			[]string{
+				"--recursive",
+				gitUrl,
+				destination,
+			}, branch)
+
 		if err != nil {
 			return fmt.Errorf("Failed to clone git repository at %s", gitUrl)
-		}
-
-		if branch != "" {
-			cmd = exec.Command(gitPath, "--git-dir="+destination+"/.git", "--work-tree="+destination, "checkout", branch)
-			err = cmd.Run()
-			if err != nil {
-				return fmt.Errorf("Failed to checkout branch '%s' for git repository at %s", branch, gitUrl)
-			}
 		}
 	}
 
 	return nil
+}
+
+func performGitClone(gitPath string, args []string, branch string) error {
+	args = append([]string{"clone"}, args...)
+
+	if branch != "" {
+		args = append(args, "-b", branch)
+	}
+	cmd := exec.Command(gitPath, args...)
+	return cmd.Run()
 }

--- a/buildpackrunner/git_buildpack_test.go
+++ b/buildpackrunner/git_buildpack_test.go
@@ -48,6 +48,18 @@ var _ = Describe("GitBuildpack", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(currentBranch(cloneTarget)).To(Equal("a_lightweight_tag"))
 			})
+
+			Context("when git repo has submodules", func() {
+				It("updates the submodules for the branch", func() {
+					branchUrl := gitUrl
+					branchUrl.Fragment = "a_branch"
+					err := buildpackrunner.GitClone(branchUrl, cloneTarget)
+					Expect(err).NotTo(HaveOccurred())
+
+					fileContents, _ := ioutil.ReadFile(cloneTarget + "/sub/README")
+					Expect(string(fileContents)).To(Equal("2nd commit"))
+				})
+			})
 		})
 
 		Context("With a Git transport that supports `--depth`", func() {


### PR DESCRIPTION
This fix is related to this [bug](https://www.pivotaltracker.com/story/show/97854548).

To verify that it worked we made a dev release of Diego and ensure that the following app was deployed to cloud-foundry.

```
mkdir app
cd app
touch Gemfile
bundle install
cf push my-awesome-app -b https://github.com/cloudfoundry/ruby-buildpack#v1.4.1 --no-start
cf enable-diego my-awesome-app
cf start my-awesome-app
cf logs my-awesome-app --recent
```

The app should successfully deploy!