### PR TITLE
return all requested process types

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -143,11 +143,11 @@ var _ = Describe("Launcher", func() {
 				"launcher",
 				appDir,
 				"",
-				`{ "start_command": "env; echo running app" }`,
+				`{ "process_types": { "web": "env; echo running app" } }`,
 			}
 		})
 
-		ItExecutesTheCommandWithTheRightEnvironment()
+		ItExecutesTheCommandWithTheRightEnvironment() // assuming web process
 	})
 
 	var ItPrintsUsageInformation = func() {

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -80,7 +80,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Invalid metadata - %s", err)
 			os.Exit(1)
 		} else {
-			command = executionMetadata.StartCommand
+			command = executionMetadata.ProcessTypes["web"]
 		}
 	} else {
 		command, err = startCommandFromStagingInfo("staging_info.yml")

--- a/models.go
+++ b/models.go
@@ -26,8 +26,7 @@ func ExitCodeFromError(err error) int {
 }
 
 type StagingResult struct {
-	BuildpackKey         string            `json:"buildpack_key,omitempty"`
-	DetectedBuildpack    string            `json:"detected_buildpack"`
-	ExecutionMetadata    string            `json:"execution_metadata"`
-	DetectedStartCommand map[string]string `json:"detected_start_command"`
+	BuildpackKey      string `json:"buildpack_key,omitempty"`
+	DetectedBuildpack string `json:"detected_buildpack"`
+	ExecutionMetadata string `json:"execution_metadata"`
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,5 +1,5 @@
 package protocol
 
 type ExecutionMetadata struct {
-	StartCommand string `json:"start_command"`
+	ProcessTypes map[string]string `json:"process_types"`
 }


### PR DESCRIPTION
- the full default_process_types from the buildpack
- the full Procfile if it exists, otherwise fallback to the buildpack
  default_process_types
- return process_types in execution_metadata
- do not return detected_start_command key any more

[#103337820]
Signed-off-by: Jonathan Berkhahn <jaberkha@us.ibm.com>
Signed-off-by: Zach Robinson <zrobinson@pivotal.io>