### PR TITLE
Implement staging and runtime hooks

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -223,6 +223,30 @@ start_command: the start command
 				})
 			})
 		})
+
+		Context("when the app uses staging hooks", func() {
+			BeforeEach(func() {
+				cp(path.Join(appFixtures, "bash-app", "pre-hook.sh"), buildDir)
+				cp(path.Join(appFixtures, "bash-app", "post-hook.sh"), buildDir)
+			})
+
+			var files []string
+
+			JustBeforeEach(func() {
+				result, err := exec.Command("tar", "-tzf", outputDroplet).Output()
+				Expect(err).NotTo(HaveOccurred())
+
+				files = strings.Split(string(result), "\n")
+			})
+
+			It("exports variables from pre-hook.sh to bin/compile", func() {
+				Expect(files).To(ContainElement("./app/PREHOOK"))
+			})
+
+			It("runs post-hook.sh after build-compile", func() {
+				Expect(files).To(ContainElement("./app/POSTHOOK"))
+			})
+		})
 	})
 
 	Context("with a buildpack that does not determine a start command", func() {

--- a/builder/fixtures/apps/bash-app/post-hook.sh
+++ b/builder/fixtures/apps/bash-app/post-hook.sh
@@ -1,0 +1,7 @@
+# test if variables exported by pre-hook.sh are visible
+if [ -n "$PREHOOK" ]; then
+    # test that always-detect/bin/compile has executed (and has seen $PREHOOK)
+    if [ -f PREHOOK ]; then
+        touch POSTHOOK
+    fi
+fi

--- a/builder/fixtures/apps/bash-app/pre-hook.sh
+++ b/builder/fixtures/apps/bash-app/pre-hook.sh
@@ -1,0 +1,1 @@
+export PREHOOK=1

--- a/builder/fixtures/buildpacks/always-detects/bin/compile
+++ b/builder/fixtures/buildpacks/always-detects/bin/compile
@@ -3,3 +3,8 @@
 
 echo WOO
 touch $1/compiled
+
+# test if variables exported by pre-hook.sh are visible
+if [ -n "$PREHOOK" ]; then
+    touch PREHOOK
+fi

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -32,6 +32,9 @@ var _ = Describe("Launcher", func() {
 		err = os.MkdirAll(appDir, 0755)
 		Expect(err).NotTo(HaveOccurred())
 
+		err = ioutil.WriteFile(filepath.Join(appDir, "run-hook.sh"), []byte("export RUNHOOK=true\n"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
 		launcherCmd = &exec.Cmd{
 			Path: launcher,
 			Dir:  extractDir,
@@ -65,6 +68,11 @@ var _ = Describe("Launcher", func() {
 		It("executes the start command with $HOME as the given dir", func() {
 			Eventually(session).Should(gexec.Exit(0))
 			Eventually(session).Should(gbytes.Say("HOME=" + appDir))
+		})
+
+		It("executes the start command after sourcing run-hook.sh", func() {
+			Eventually(session).Should(gexec.Exit(0))
+			Eventually(session).Should(gbytes.Say("RUNHOOK=true"))
 		})
 
 		It("changes to the app directory when running", func() {

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -21,6 +21,10 @@ if [ -d .profile.d ]; then
   done
 fi
 
+if [ -f run-hook.sh ]; then
+  source run-hook.sh
+fi
+
 shift
 
 exec bash -c "$@"


### PR DESCRIPTION
The buildpack team tried to implement pre- and post-staging hooks as an
experiment:

https://www.pivotaltracker.com/n/projects/1042066/stories/96592310

That approach didn't really work out because it requires the
functionality to be implemented in each buildpack.

This change implements the change directly inside the buildpackrunner,
making the functionality available even to buildpacks not based on
"compile-extensions".

The run-hook.sh adds similar functionality to the launcher.  If the
pre-hook.sh installs additional OS packages, then similar packages
might be needed before launching because the OS packages are not
persisted inside the droplet.