### PR TITLE
Add .profile script support

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -111,14 +111,20 @@ var _ = Describe("Launcher", func() {
 
 				err = ioutil.WriteFile(path.Join(profileDir, "b.sh"), []byte("echo sourcing b\nexport B=1\n"), 0644)
 				Expect(err).NotTo(HaveOccurred())
+
+				err = ioutil.WriteFile(path.Join(appDir, ".profile"), []byte("echo sourcing .profile\nexport C=$A$B\n"), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
 			})
 
-			It("sources them before executing", func() {
+			It("sources them before sourcing .profile and before executing", func() {
 				Eventually(session).Should(gexec.Exit(0))
 				Eventually(session).Should(gbytes.Say("sourcing a"))
 				Eventually(session).Should(gbytes.Say("sourcing b"))
+				Eventually(session).Should(gbytes.Say("sourcing .profile"))
 				Eventually(session).Should(gbytes.Say("A=1"))
 				Eventually(session).Should(gbytes.Say("B=1"))
+				Eventually(session).Should(gbytes.Say("C=11"))
 				Eventually(session).Should(gbytes.Say("running app"))
 			})
 		})

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -21,6 +21,10 @@ if [ -d .profile.d ]; then
   done
 fi
 
+if [ -f .profile ]; then
+  source .profile
+fi
+
 shift
 
 exec bash -c "$@"


### PR DESCRIPTION
This PR has been separated out from #13.  It only implements a feature already part of the Heroku buildpack spec, so should hopefully be less contentious.

The buildpack API spec at Heroku says:

> Scripts in `.profile.d/` should only be written by buildpacks. Customers intending to perform application specific initialization tasks at the time a dyno boots should use `.profile` scripts, which are guaranteed to run after the scripts in `.profile.d/`.

https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts

The droplet launcher already has support for `.profile.d/` scripts. This commit adds support for sourcing the `.profile` script as well.